### PR TITLE
Move to api v2, and use 'status=actual' for parcel requests.

### DIFF
--- a/crabpy/gateway/capakey.py
+++ b/crabpy/gateway/capakey.py
@@ -62,7 +62,7 @@ class CapakeyRestGateway(object):
     def __init__(self, **kwargs):
         self.base_url = kwargs.get(
             'base_url',
-            'https://geoservices.informatievlaanderen.be/capakey/api/v1'
+            'https://geoservices.informatievlaanderen.be/capakey/api/v2'
         )
         self.base_headers = {
             'Accept': 'application/json'
@@ -383,7 +383,8 @@ class CapakeyRestGateway(object):
             url = self.base_url + '/municipality/%s/department/%s/section/%s/parcel' % (gid, aid, sid)
             h = self.base_headers
             p = {
-                'data': 'adp'
+                'data': 'adp',
+                'status': 'actual'
             }
             res = capakey_rest_gateway_request(url, h, p).json()
             return [
@@ -424,7 +425,8 @@ class CapakeyRestGateway(object):
             p = {
                 'geometry': 'full',
                 'srs': '31370',
-                'data': 'adp'
+                'data': 'adp',
+                'status': 'actual'
             }
             res = capakey_rest_gateway_request(url, h, p).json()
             return Perceel(
@@ -461,7 +463,8 @@ class CapakeyRestGateway(object):
             p = {
                 'geometry': 'full',
                 'srs': '31370',
-                'data': 'adp'
+                'data': 'adp',
+                'status': 'actual'
             }
             res = capakey_rest_gateway_request(url, h, p).json()
             return Perceel(

--- a/tests/gateway/test_capakey.py
+++ b/tests/gateway/test_capakey.py
@@ -117,8 +117,8 @@ class TestCapakeyRestGateway:
         assert isinstance(res, Perceel)
         assert res.sectie.id == 'A'
         assert res.sectie.afdeling.id == 44021
-        assert res.centroid == (104036.06610000134, 194676.8699000012)
-        assert res.bounding_box == (104029.2602000013, 194665.0236000009, 104042.87200000137, 194688.71620000154)
+        assert res.centroid == (104036.06609148532, 194676.86989716627)
+        assert res.bounding_box == (104029.26020348072, 194665.0235611573, 104042.87197948992, 194688.71623317525)
         assert res.shape is not None
 
     def test_get_perceel_by_percid(self, capakey_rest_gateway):


### PR DESCRIPTION
Verschil tussen v1 en v2 bij 1 test:

![image](https://user-images.githubusercontent.com/4599667/59773812-926b9680-92ae-11e9-95d2-709e41ab4976.png)
